### PR TITLE
fix(release): removes dry-run param from semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --collect-coverage",
     "prepare": "husky install",
-    "release": "semantic-release --dry-run --pkgRoot=dist/package/ --branches='main'"
+    "release": "semantic-release --pkgRoot=dist/package/ --branches='main'"
   },
   "main": "src/index.ts",
   "typings": "src/types/typing.d.ts",


### PR DESCRIPTION
To perform a test I added the --dry-run flag to check if the correct package version will be released. This PR reverts the change.