### PR TITLE
feat: allow string IDs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,8 @@ export default {
     }
 
     if (isHotjarOptionsValid(options) && isVueVersionValid(app)) {
-      new Hotjar(options.id, options.snippetVersion, options.isProduction);
+      const HotjarId = typeof options.id === 'string' ? parseInt(options.id) : options.id;
+      new Hotjar(HotjarId, options.snippetVersion, options.isProduction);
       if (window.hj) {
         app.config.globalProperties.$hj = window.hj;
         app.config.globalProperties.$hjSettings = window._hjSettings;

--- a/src/libs/validation/validation.spec.ts
+++ b/src/libs/validation/validation.spec.ts
@@ -11,9 +11,9 @@ describe('validation', () => {
   })
   it('isHotjarOptionsValid should print an error that the option ID is invalid', () => {
     const validationResult = isHotjarOptionsValid({
-      id: '11111',
+      id: 11111.111,
     } as any)
-    expect(console.error).toHaveBeenCalledWith('vue-hotjar-next: Hotjar option site id is of type string and should a number');
+    expect(console.error).toHaveBeenCalledWith('vue-hotjar-next: Hotjar option site id is of type float and should a number or string');
     expect(validationResult).toBeFalsy();
   });
 
@@ -47,6 +47,14 @@ describe('validation', () => {
   it('isHotjarOptionsValid should be valid', () => {
     const validationResult = isHotjarOptionsValid({
       id: 11111,
+    })
+    expect(console.error).not.toHaveBeenCalled();
+    expect(validationResult).toBeTruthy();
+  });
+
+    it('isHotjarOptionsValid should be valid as a string', () => {
+    const validationResult = isHotjarOptionsValid({
+      id: '11111',
     })
     expect(console.error).not.toHaveBeenCalled();
     expect(validationResult).toBeTruthy();

--- a/src/libs/validation/validation.spec.ts
+++ b/src/libs/validation/validation.spec.ts
@@ -11,9 +11,9 @@ describe('validation', () => {
   })
   it('isHotjarOptionsValid should print an error that the option ID is invalid', () => {
     const validationResult = isHotjarOptionsValid({
-      id: 11111.111,
+      id: true,
     } as any)
-    expect(console.error).toHaveBeenCalledWith('vue-hotjar-next: Hotjar option site id is of type float and should a number or string');
+    expect(console.error).toHaveBeenCalledWith('vue-hotjar-next: Hotjar option site id is of type boolean and should be a number or string');
     expect(validationResult).toBeFalsy();
   });
 

--- a/src/libs/validation/validation.ts
+++ b/src/libs/validation/validation.ts
@@ -31,9 +31,9 @@ export function isHotjarOptionsValid(
   }
 
   // check if id option is of type number
-  if (typeof options.id !== 'number') {
+  if (typeof options.id !== 'number' || typeof options.id !== 'string') {
     console.error(
-      `vue-hotjar-next: Hotjar option site id is of type ${typeof options.id} and should a number`
+      `vue-hotjar-next: Hotjar option site id is of type ${typeof options.id} and should be a number or string`
     );
     return false
   }
@@ -50,7 +50,7 @@ export function isHotjarOptionsValid(
  *
  */
 export function isVueVersionValid(app: App): boolean {
-  
+
   if (app.version[0] !== '3') {
     console.error(
       `vue-hotjar-next: This plugin is intended to be used with Vue version 3. Version ${app.version} was detected.`

--- a/src/libs/validation/validation.ts
+++ b/src/libs/validation/validation.ts
@@ -31,7 +31,7 @@ export function isHotjarOptionsValid(
   }
 
   // check if id option is of type number
-  if (typeof options.id !== 'number' || typeof options.id !== 'string') {
+  if (typeof options.id !== 'number' && typeof options.id !== 'string') {
     console.error(
       `vue-hotjar-next: Hotjar option site id is of type ${typeof options.id} and should be a number or string`
     );

--- a/src/types/typing.d.ts
+++ b/src/types/typing.d.ts
@@ -4,7 +4,7 @@ export interface HotjarOptions {
   /**
    * Your Hotjar Site ID is a required parameter. You can find this ID at [insights.hotjar.com](https://insights.hotjar.com).
    */
-  id: number;
+  id: number | string;
 
   /**
    * If you would like to disable or enable tracking, pass in either `true` or `false`. Ideally you want to set this to prevent unintentional tracking during local development.


### PR DESCRIPTION
This PR adds handling of string IDs, and corrects a tiny spelling mistake (or rather word omission) in the original error message.

This PR was created because the most likely place people will store the HotJar ID is in an .env file, which returns strings - so this convenience PR allows users to pass either strings or numbers.

The original issue is here: https://github.com/henk-badenhorst/vue-hotjar-next/issues/16?notification_referrer_id=NT_kwDOANJpKbQxMDM5NTYzNDU3NToxMzc4OTQ4MQ#issuecomment-2103145597